### PR TITLE
Loss function fixed

### DIFF
--- a/loss.py
+++ b/loss.py
@@ -27,11 +27,11 @@ class FastSpeech2Loss(nn.Module):
         mel_postnet = mel_postnet.masked_select(mel_mask.unsqueeze(-1))
         mel_target = mel_target.masked_select(mel_mask.unsqueeze(-1))
 
-        mel_loss = self.mse_loss(mel, mel_target)
-        mel_postnet_loss = self.mse_loss(mel_postnet, mel_target)
+        mel_loss = self.mae_loss(mel, mel_target)
+        mel_postnet_loss = self.mae_loss(mel_postnet, mel_target)
 
-        d_loss = self.mae_loss(log_d_predicted, log_d_target)
-        p_loss = self.mae_loss(p_predicted, p_target)
-        e_loss = self.mae_loss(e_predicted, e_target)
+        d_loss = self.mse_loss(log_d_predicted, log_d_target)
+        p_loss = self.mse_loss(p_predicted, p_target)
+        e_loss = self.mse_loss(e_predicted, e_target)
         
         return mel_loss, mel_postnet_loss, d_loss, p_loss, e_loss


### PR DESCRIPTION
While I was reviewing the code and the fastspeech2 paper(https://arxiv.org/abs/2006.04558), I realized they used mse loss function for duration/pitch/energy predictors and mae loss function for the mel spectrogram models. (Quoted from page 4 Duration Predictor/Pitch Predictor/Energy Predictor and page 6 Model Configuration paragraphs)

Let me know how this looks. Any comments will be appreciated. Thanks!


