### PR TITLE
preprocess 실행 시 TextGrid 파일이 없을 때 에러가 발생하는 문제 수정

### DIFF
--- a/data/kss.py
+++ b/data/kss.py
@@ -66,11 +66,14 @@ def process_utterance(in_dir, out_dir, basename, scalers):
     wav_bak_path = os.path.join(in_dir, "wavs_bak", "{}.wav".format(wav_bak_basename))
     wav_path = os.path.join(in_dir, 'wavs', '{}.wav'.format(basename))
 
+    tg_path = os.path.join(out_dir, 'TextGrid', '{}.TextGrid'.format(basename)) 
+    if not os.path.exists(tg_path):
+        return None
+
     # Convert kss data into PCM encoded wavs
     if not os.path.isfile(wav_path):
-        os.system("ffmpeg -i {} -ac 1 -ar 22050 {}".format(wav_bak_path, wav_path))    
-    tg_path = os.path.join(out_dir, 'TextGrid', '{}.TextGrid'.format(basename)) 
-    
+        os.system("ffmpeg -i {} -ac 1 -ar 22050 {}".format(wav_bak_path, wav_path))
+
     # Get alignments
     textgrid = tgt.io.read_textgrid(tg_path)
     phone, duration, start, end = get_alignment(textgrid.get_tier_by_name('phones'))


### PR DESCRIPTION
안녕하세요. 이재홍입니다.

현재 최신 버전의 MFA(2.0.6)에서 KSS Dataset의 TextGrid를 추출해본 결과 몇 개가 추출에 실패하는 것으로 확인되었습니다.

따라서, TextGrid가 없는 경우 에러가 발생하지 않도록 코드를 수정하였습니다.